### PR TITLE
moved .ev to gitignore

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-USER = thakur0805
-USER_KEY = shubham

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+evFiles

--- a/db.js
+++ b/db.js
@@ -1,5 +1,5 @@
 const mongoose = require('mongoose');
-require('dotenv').config()
+require('dotenv').config({path: "./evFiles/.env"})
 
 const connectToMongoDB = async () => {
     try {


### PR DESCRIPTION
As per the feedback collected for the last PR, the .ev file was moved to .gitignore. The reason was to prevent any leak of confidential data for nefarious purposes. It was moved to a folder which was mentioned in the .gitignore file.